### PR TITLE
Clip player UI tweaks

### DIFF
--- a/frontend/src/pages/components/clipViewer/CustomPlayer.js
+++ b/frontend/src/pages/components/clipViewer/CustomPlayer.js
@@ -22,6 +22,19 @@ const CustomPlayer = ({ currentClip }) => {
     }, []);
 
     useEffect(() => {
+        const handleFullscreen = (e) => {
+            if(document.fullscreenElement == divRef?.current) {
+                setIsFullscreen(true);
+            } else {
+                setIsFullscreen(false);
+            }
+        }
+        handleFullscreen();
+        window.addEventListener('fullscreenchange', handleFullscreen);
+        return () => window.removeEventListener('fullscreenchange', handleFullscreen);
+    }, []);
+
+    useEffect(() => {
         const handlePause = () => setIsPlaying(false);
         const handlePlay = () => setIsPlaying(true);
         const ref = videoRef.current; // create new ref variable because react throws a fit if "videoRef.current" is called during cleanup lol
@@ -72,10 +85,8 @@ const CustomPlayer = ({ currentClip }) => {
         if (divRef.current.requestFullscreen) {
             if(isFullscreen) {
                 document.exitFullscreen();
-                setIsFullscreen(false);
             } else {
                 divRef.current.requestFullscreen();
-                setIsFullscreen(true);
             }
         }
     };


### PR DESCRIPTION
Fullscreen mode shows the new custom UI, the button changes icon depending on whether or not it's in fullscreen mode
![image](https://github.com/user-attachments/assets/e66f6ed7-4524-406c-8e66-9892fa1e91f9)
![image](https://github.com/user-attachments/assets/e24ea68e-b3f6-4176-aaa0-516e6c9db7bb)

aaaand the UI stretches across the screen depending on if it's rendered in a mobile view or not
![image](https://github.com/user-attachments/assets/9606fe19-0ef6-4f5d-8f42-806385959118)
![image](https://github.com/user-attachments/assets/284db579-659a-4e8f-8e0f-48c9fa8f5c2d)

(play/pause & fullscreen button change by events too, so when the video ends it doesn't keep showing the pause button)