### PR TITLE
Optimizing video network usage

### DIFF
--- a/frontend/src/pages/components/clipViewer/ClipItem.js
+++ b/frontend/src/pages/components/clipViewer/ClipItem.js
@@ -63,7 +63,6 @@ const ClipItem = ({ clip, hasUserRated, setExpandedClip, index }) => {
         onPlaying={(e) => {
           if(clip.thumbnail && !e.target.classList.contains(`group-hover:opacity-100`)) {
             e.target.classList.add(`group-hover:opacity-100`)
-            console.log(`added opacity`);
 
             if(!thumbnailRef?.current?.classList.contains(`group-hover:opacity-0`)) {
               thumbnailRef.current.classList.add(`group-hover:opacity-0`)


### PR DESCRIPTION
setting video preload to `metadata` seems to just load the entire video on mp4 containers, which is pretty much what every video stored is using, making each page take quite a bit of bandwidth . rip metered bandwidth users

(this pr sets video preload to `none` so long as a thumbnail exists, and only loads it once hovered)